### PR TITLE
開発環境では rack-cors で CORS の制限を回避できるようにする

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -32,7 +32,7 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem 'rack-cors'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -171,6 +171,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
@@ -194,6 +196,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (3.0.8)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -268,6 +272,7 @@ GEM
     shoulda-context (2.0.0)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
+    sqlite3 (1.6.7-aarch64-linux)
     sqlite3 (1.6.7-x86_64-darwin)
     sqlite3 (1.6.7-x86_64-linux)
     stringio (3.0.8)
@@ -283,6 +288,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-21
   x86_64-linux
 
@@ -301,6 +307,7 @@ DEPENDENCIES
   mocha
   pry-rails
   puma (>= 5.0)
+  rack-cors
   rails (~> 7.1.0)
   rubocop
   rubocop-rails

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -5,12 +5,14 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  if Rails.env.development?
+    allow do
+      origins /\Ahttps?:\/\/localhost(:\d+)?\z/, /https?:\/\/127\.0\.0\.1(:\d+)?\z/
+
+      resource "*",
+        headers: :any,
+        methods: [:get, :post, :put, :patch, :delete, :options, :head]
+    end
+  end
+end


### PR DESCRIPTION
最終的には同じオリジンで提供されるが、現状はフロントの開発をホストで行っているため同じオリジンにできないので…