### PR TITLE
Ruby のバージョンを指定しないようにする

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '3.2.2'
-
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.1.0'
 


### PR DESCRIPTION
CI が失敗しちゃうので