### PR TITLE
タイムゾーンを考慮できるようにする

### DIFF
--- a/api/config/application.rb
+++ b/api/config/application.rb
@@ -28,5 +28,7 @@ module App
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.time_zone = ENV['TZ'] || 'UTC'
   end
 end

--- a/cloudrun/service.yaml
+++ b/cloudrun/service.yaml
@@ -49,6 +49,8 @@ spec:
               cpu: "1.0"
               memory: 256Mi
           env:
+            - name: TZ
+              value: Asia/Tokyo
             - name: RAILS_ENV
               value: production
             - name: RAILS_LOG_TO_STDOUT


### PR DESCRIPTION
環境変数に入れてるけどタイムゾーンの変更がうまく動かないので、 application.rb 上で `time_zone` に `ENV['TZ']` が読み込まれるようにする